### PR TITLE
Fix "Home"  and "User Manager" buttons.

### DIFF
--- a/letsencrypt-cpanel-ui/index.tt
+++ b/letsencrypt-cpanel-ui/index.tt
@@ -180,6 +180,8 @@
   </script>
   [% IF (theme == 'paper_lantern') %]
     <script type="text/javascript">
+  	$("#sidebar_home").prop("href", "[% base_url %]index.html");
+	$("#sidebar_user_manager").prop("href", "[% base_url %]user_manager/index.html");
         $("#lnkHeaderHome").prop("href", "[% base_url %]index.html");
         $("#lnkQuickHome").prop("href", "[% base_url %]index.html");
         $("#lnkQuickDomains").prop("href", "[% base_url %]addon/index.html");


### PR DESCRIPTION
cPanel V.11.60.0.5 uses "#sidebar_home" and "#sidebar_user_manager" class names. Without this fix, users are sent to "frontend/3rdParty/index.html" when they click home button, which gives 404 error.
